### PR TITLE
Add Docker support for front-end

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,12 +1,9 @@
-# Don't check auto-generated stuff into git
 coverage
 build
 stats.json
 dist
 
-# Cruft
 .DS_Store
 npm-debug.log
 .idea
-
 .github

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  frontend:
+    image: kkarczmarczyk/node-yarn
+    ports:
+     - "80:3000"
+    volumes:
+     - .:/home/app/dot-print-frontend
+     - /home/app/dot-print-frontend/node_modules
+    command: bash -c "cd /home/app/dot-print-frontend && yarn install && npm start"


### PR DESCRIPTION
You can now user `docker-compose up` to run the front-end on `localhost`.